### PR TITLE
Fix bug with exporting samples to file on Windows

### DIFF
--- a/snowmicropyn/profile.py
+++ b/snowmicropyn/profile.py
@@ -455,7 +455,7 @@ class Profile(object):
                 'force': 'force [N]',
             }
             data = samples.rename(columns=with_units)
-            data.to_csv(f, header=True, index=False, float_format=fmt)
+            data.to_csv(f, header=True, index=False, float_format=fmt, lineterminator='\n')
         return file
 
     def export_samples_niviz(self, export_settings, file=None, precision=4):


### PR DESCRIPTION
Using `snowmicropyn v1.2.1` installed from pypi

On Windows, the default `lineterminator` for `pandas.Dataframe.to_csv` is `\r\n`. Unfortunately this causes `snowmicropyn.Profile.export_samples` to produce outputs that look like this:

```
# Exported by snowmicropyn 1.2.1 (git hash None)
distance [mm],force [N]

0.0000,0.1245

0.0041,0.1218

0.0083,0.1245

0.0124,0.1245

0.0165,0.1245

0.0207,0.1245

0.0248,0.1245

0.0289,0.1245

0.0331,0.1245

0.0372,0.1218
```

With the change introduced in 06cfe5b, the `lineterminator` is forced to be `\n` which produces the following on both Windows and Linux:

```
# Exported by snowmicropyn 1.2.1 (git hash None)
distance [mm],force [N]
0.0000,0.1245
0.0041,0.1218
0.0083,0.1245
0.0124,0.1245
0.0165,0.1245
0.0207,0.1245
0.0248,0.1245
0.0289,0.1245
0.0331,0.1245
0.0372,0.1218
```
