### PR TITLE
Messages as popups

### DIFF
--- a/snowmicropyn/pyngui/main_window.py
+++ b/snowmicropyn/pyngui/main_window.py
@@ -729,7 +729,7 @@ class NoDocWidget(QWidget):
 class NotificationDialog(QDialog):
     def __init__(self, *args):
         super(NotificationDialog, self).__init__(*args)
-
+        self.setWindowFlags(Qt.Popup)
         self.hint_label = QLabel()
         self.hint_label.setWordWrap(True)
         self.content_textedit = QTextEdit()


### PR DESCRIPTION
Add Qt Flag to turn messages into popups that can be closed by clicking outside the popup window.